### PR TITLE
New panStamp esp-output board definition file

### DIFF
--- a/panstamp_esp-output.json
+++ b/panstamp_esp-output.json
@@ -6,7 +6,7 @@
         {
           "pins": 
             {
-			          "Relay0":  16,  "Relay1":  14,  "Relay2":  12,  "Relay3":  13,  "Relay4":  4, "Relay5":  5 
+                "Relay0":  16,  "Relay1":  14,  "Relay2":  12,  "Relay3":  13,  "Relay4":  4, "Relay5":  5 
             },
             "ops": [ "dw" ]
         }

--- a/panstamp_esp-output.json
+++ b/panstamp_esp-output.json
@@ -1,0 +1,14 @@
+{
+    "name": "panStamp esp-output",
+    "map": 
+    {
+        "digital": 
+        {
+          "pins": 
+            {
+			          "Relay0":  16,  "Relay1":  14,  "Relay2":  12,  "Relay3":  13,  "Relay4":  4, "Relay5":  5 
+            },
+            "ops": [ "dw" ]
+        }
+    }
+}


### PR DESCRIPTION
JSON file for the panStamp esp-output board. This board is based on the ESP8266 WiFi MCU and provides six 10A relay outputs.

More information about this board [here](https://github.com/panStamp/esp8266/tree/master/esp-output).
