### PR TITLE
Add KidBright32 board

### DIFF
--- a/KidBright32.json
+++ b/KidBright32.json
@@ -1,0 +1,60 @@
+{
+    "name": "KidBright32",
+    "based_on": "https://www.kid-bright.org/",
+    "map": {
+        "digital": {
+            "pins": {
+                "OUT1": 26,
+                "OUT2": 27,
+                "IN1": 32,
+                "IN2": 33,
+                "IN3": 34,
+                "IN4": 35,
+                "USB": 25,
+                "SW1": 16,
+                "SW2": 14,
+                "BT LED": 17,
+                "WIFI LED": 2,
+                "NTP LED": 15,
+                "IOT LED": 12,
+                "gp18": 18,
+                "gp19": 19,
+                "gp23": 23
+            },
+            "ops": [
+                "dr",
+                "dw"
+            ]
+        },
+        "analog": {
+            "pins": {},
+            "ops": [
+                "ar"
+            ],
+            "arRange": [
+                0,
+                1023
+            ]
+        },
+        "pwm": {
+            "pins": [],
+            "ops": [
+                "aw"
+            ],
+            "awRange": [
+                0,
+                1023
+            ]
+        },
+        "virtual": {
+            "pinsRange": [
+                0,
+                255
+            ],
+            "ops": [
+                "vr",
+                "vw"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
[KidBright32](https://www.kid-bright.org/) is microcontroller board for education (same as micro:bit from BBC) develop by National Electronics and Computer Technology Center (NECTEC) from Thailand and support by Thai government. Over 200,000 boards were distributed to schools across the country. Student in thailand use KidBright32 for STEM education and make project so Blynk application support KidBright32 is very important

![KidBright32](https://i.ibb.co/cyK2PQ1/Kid-Bright32-V1-3.jpg)

![KidBright32 Advanced User Diagram](https://kidbright.info/files/KidBright-advanced-user-diagram.jpg)

## Here is a little bit about KidBright32

 * Base on ESP32
 * [KidBrightIDE](https://gitlab.com/kidbright/kbide) , [KBIDE](https://kbide.org/) and [microBlock IDE](https://microblock.app/) use for programmable KidBright32
 * [KidBright32 Board is Thailand’s BBC Micro:Bit Equivalent](https://www.cnx-software.com/2018/07/16/kidbright32-thailand-bbc-micro-bit/)

I will await your reply. Thanks.
